### PR TITLE
fix: allow logged-out users to view unlisted thread messages

### DIFF
--- a/supabase/migrations/20250211000001_allow_unlisted_messages_access.sql
+++ b/supabase/migrations/20250211000001_allow_unlisted_messages_access.sql
@@ -1,0 +1,11 @@
+-- ABOUTME: Updates messages RLS to allow anyone to view messages via direct session link
+-- ABOUTME: Aligns with sessions table policy from 20250206000001_allow_unlisted_access.sql
+
+-- Drop the restrictive select policy
+DROP POLICY IF EXISTS "messages_select_via_session" ON messages;
+
+-- Allow SELECT on all messages (session ID acts as capability token)
+-- If you have the session ID, you can read its messages
+CREATE POLICY "messages_select_all"
+  ON messages FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary

- Updates messages table RLS policy to match sessions table approach
- Session ID acts as capability token - if you have the link, you can view the messages
- Fixes logged-out users seeing empty conversation on unlisted threads

Fixes #17

## Test plan

- [ ] Open an unlisted thread URL in incognito/logged-out browser
- [ ] Verify conversation content loads correctly

## Session

https://claudebin.com/threads/mvo5w1po73