### PR TITLE
fix: XSS injection in thread pages via URL sanitization (#43)

### DIFF
--- a/app/src/components/thread-page-conversation-attachment-chip.tsx
+++ b/app/src/components/thread-page-conversation-attachment-chip.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import type { Attachment } from "@/supabase/types/message";
 
 import { THREAD_ATTACHMENT_SIZE } from "@/utils/constants";
+import { sanitizeUrl } from "@/utils/sanitizeUrl";
 
 import { SvgIconFile } from "@/components/icon/svg-icon-file";
 import { Chip } from "@/components/ui/chip";
@@ -15,11 +16,15 @@ type ThreadPageConversationAttachmentChipProps = {
   attachment: Attachment;
 };
 
+const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"];
+
 const resolveDataUrlSrc = (attachment: Attachment) => {
   if (attachment.sourceType === "url") {
-    return attachment.data;
+    return sanitizeUrl(attachment.data);
   }
-  return `data:${attachment.mediaType ?? "image/png"};base64,${attachment.data}`;
+  const mediaType = attachment.mediaType ?? "image/png";
+  if (!ALLOWED_IMAGE_TYPES.includes(mediaType)) return "";
+  return `data:${mediaType};base64,${attachment.data}`;
 };
 
 const ThreadPageConversationAttachmentChip = ({

--- a/app/src/components/thread-page-conversation-text.tsx
+++ b/app/src/components/thread-page-conversation-text.tsx
@@ -23,6 +23,8 @@ import {
   TableCell,
 } from "@/components/ui/table";
 
+import { sanitizeUrl } from "@/utils/sanitizeUrl";
+
 import { ThreadPageConversationAttachmentChip } from "@/components/thread-page-conversation-attachment-chip";
 
 type CodeElementProps = {
@@ -71,7 +73,12 @@ const createComponents = (role: Role) => ({
     <Typography variant="small">{children}</Typography>
   ),
   a: ({ href, children }: { href?: string; children?: ReactNode }) => (
-    <a href={href} className="text-orange-50 hover:underline">
+    <a
+      href={sanitizeUrl(href)}
+      rel="noopener noreferrer"
+      target="_blank"
+      className="text-orange-50 hover:underline"
+    >
       {children}
     </a>
   ),
@@ -98,7 +105,7 @@ const ThreadPageConversationText = ({ block }: ThreadPageConversationTextProps) 
   return (
     <div className="flex max-w-full flex-col gap-4 break-all [&>*:first-child]:mt-0">
       {block.text.trim().length ? (
-        <Markdown remarkPlugins={REMARK_PLUGINS} components={components}>
+        <Markdown remarkPlugins={REMARK_PLUGINS} urlTransform={sanitizeUrl} components={components}>
           {block.text}
         </Markdown>
       ) : null}

--- a/app/src/utils/sanitizeUrl.test.ts
+++ b/app/src/utils/sanitizeUrl.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeUrl } from "./sanitizeUrl";
+
+describe("sanitizeUrl", () => {
+  test("allows https URLs", () => {
+    expect(sanitizeUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  test("allows http URLs", () => {
+    expect(sanitizeUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  test("allows mailto URLs", () => {
+    expect(sanitizeUrl("mailto:user@example.com")).toBe("mailto:user@example.com");
+  });
+
+  test("allows relative URLs", () => {
+    expect(sanitizeUrl("/path/to/page")).toBe("/path/to/page");
+  });
+
+  test("allows fragment URLs", () => {
+    expect(sanitizeUrl("#section")).toBe("#section");
+  });
+
+  test("blocks javascript: protocol", () => {
+    expect(sanitizeUrl("javascript:alert(1)")).toBe("");
+  });
+
+  test("blocks javascript: with uppercase", () => {
+    expect(sanitizeUrl("JavaScript:alert(1)")).toBe("");
+  });
+
+  test("blocks javascript: with mixed case", () => {
+    expect(sanitizeUrl("jAvAsCrIpT:alert(1)")).toBe("");
+  });
+
+  test("blocks javascript: with leading whitespace", () => {
+    expect(sanitizeUrl("  javascript:alert(1)")).toBe("");
+  });
+
+  test("blocks javascript: with tabs and newlines", () => {
+    expect(sanitizeUrl("\t\njavascript:alert(1)")).toBe("");
+  });
+
+  test("blocks vbscript: protocol", () => {
+    expect(sanitizeUrl("vbscript:msgbox('xss')")).toBe("");
+  });
+
+  test("blocks data: protocol", () => {
+    expect(sanitizeUrl("data:text/html,<script>alert(1)</script>")).toBe("");
+  });
+
+  test("blocks data: with base64", () => {
+    expect(sanitizeUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")).toBe("");
+  });
+
+  test("returns empty string for undefined", () => {
+    expect(sanitizeUrl(undefined)).toBe("");
+  });
+
+  test("returns empty string for empty string", () => {
+    expect(sanitizeUrl("")).toBe("");
+  });
+
+  test("allows URLs with query params", () => {
+    expect(sanitizeUrl("https://example.com?q=test&foo=bar")).toBe(
+      "https://example.com?q=test&foo=bar",
+    );
+  });
+
+  test("allows URLs with hash fragments", () => {
+    expect(sanitizeUrl("https://example.com/page#section")).toBe(
+      "https://example.com/page#section",
+    );
+  });
+});

--- a/app/src/utils/sanitizeUrl.ts
+++ b/app/src/utils/sanitizeUrl.ts
@@ -1,0 +1,9 @@
+// ABOUTME: Whitelist-based URL sanitizer to prevent XSS via javascript:, data:, vbscript: protocols
+const SAFE_URL_PATTERN = /^(https?:|mailto:|\/|#)/i;
+
+export const sanitizeUrl = (url: string | undefined): string => {
+  if (!url) return "";
+  const trimmed = url.replace(/^[\s\t\n\r]+/, "");
+  if (!trimmed) return "";
+  return SAFE_URL_PATTERN.test(trimmed) ? url : "";
+};

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -29,5 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary

Closes #43. Malicious URLs in markdown links and attachment image sources in thread pages could execute arbitrary JavaScript via `javascript:` and similar protocol schemes. This adds a whitelist-based URL sanitizer that blocks all non-safe protocols at the component layer.

## Changes

- **NEW** `app/src/utils/sanitizeUrl.ts` — Whitelist-based URL sanitizer; permits `http:`, `https:`, `mailto:`, relative paths, and fragment-only URLs. Blocks `javascript:`, `data:`, `vbscript:`, and all other unlisted protocols.
- **NEW** `app/src/utils/sanitizeUrl.test.ts` — 17 tests covering safe protocols, dangerous protocols, case-variation bypass attempts, and whitespace-padded tricks.
- **MODIFIED** `app/src/components/thread-page-conversation-text.tsx` — Passes `urlTransform={sanitizeUrl}` to the `<Markdown>` component and applies `sanitizeUrl(href)` + `rel="noopener noreferrer"` + `target="_blank"` on rendered `<a>` tags.
- **MODIFIED** `app/src/components/thread-page-conversation-attachment-chip.tsx` — Validates URL-type attachment sources through `sanitizeUrl` and whitelists allowed image MIME types before rendering.
- **MODIFIED** `app/tsconfig.json` — Excludes `*.test.ts` files from the Next.js type-check compilation (test files live in `utils/` alongside source).

## Claudebin Session

🔗 [Session Link](https://claudebin.com/threads/IbMuOBhouj)

## Testing

- 17 unit tests in `sanitizeUrl.test.ts` cover all attack vectors: `javascript:`, `data:`, `vbscript:`, mixed-case variants (`JAVASCRIPT:`, `Javascript:`), whitespace-padded inputs, and all safe/allowed protocol variants.
- Manually verified that existing thread pages render markdown links and attachment chips correctly after the change.
- `bun check` and `bun type-check` pass.

## Checklist

- [x] `bun check` passes
- [x] `bun type-check` passes
- [x] Tested locally
- [x] Claudebin session link attached