### PR TITLE
fix: add Suspense boundaries for cacheComponents build

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -10,7 +10,6 @@ const root = process.env.VERCEL ? "/vercel/path0" : resolve(__dirname, "../..");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  dynamicIO: false,
   cacheComponents: true,
   outputFileTracingRoot: root,
   turbopack: {

--- a/app/src/app/(embed)/threads/[id]/embed/page.tsx
+++ b/app/src/app/(embed)/threads/[id]/embed/page.tsx
@@ -1,89 +1,26 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
-import { isNil, not } from "ramda";
+import { Suspense } from "react";
 
-import { createClient } from "@/server/supabase/server";
-import { sessions } from "@/server/repos/sessions";
-import { messages } from "@/server/repos/messages";
-
-import { compactConversation } from "@/utils/helpers";
-
-import { SvgIconArrowLink } from "@/components/icon/svg-icon-arrow-link";
-import { Typography } from "@/components/ui/typography";
-import { EmbedPageFooter } from "@/components/embed-page-footer";
-import { EmbedPageConversation } from "@/components/embed-page-conversation";
+import { SkeletonBar } from "@/components/ui/skeleton";
+import { EmbedPageContent } from "@/components/embed-page-content";
 
 type EmbedPageProps = {
   params: Promise<{ id: string }>;
   searchParams: Promise<{ from?: string; to?: string }>;
 };
 
-const EmbedPage = async ({ params, searchParams }: EmbedPageProps) => {
-  const t = await getTranslations();
-
-  const { id } = await params;
-  const { from, to } = await searchParams;
-
-  if (isNil(from) || isNil(to)) {
-    notFound();
-  }
-
-  const fromId = Number.parseInt(from);
-  const toId = Number.parseInt(to);
-
-  if (Number.isNaN(fromId) || Number.isNaN(toId) || fromId > toId) {
-    notFound();
-  }
-
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  const thread = await sessions.getByIdWithAuthor(supabase, id, user?.id);
-
-  if (isNil(thread)) {
-    notFound();
-  }
-  if (not(thread.isPublic) && thread.userId !== user?.id) {
-    notFound();
-  }
-
-  const result = await messages.getByRange(supabase, id, fromId, toId);
-
+const EmbedPage = ({ params, searchParams }: EmbedPageProps) => {
   return (
     <div className="flex min-h-screen min-w-full flex-col gap-3 bg-gray-100">
-      <div className="flex flex-col gap-4 px-4 pt-4">
-        <Typography variant="body" fontWeight="semibold">
-          {thread.title}
-        </Typography>
-
-        <EmbedPageConversation
-          messages={compactConversation(result.messages)}
-          avatarUrl={thread.profiles?.avatarUrl}
-          author={thread.profiles?.username ?? t("common.deactivated")}
-        />
-
-        <div className="flex justify-end">
-          <Link href={`/threads/${id}`} target="_blank" className="flex items-center gap-3">
-            <Typography variant="small" fontWeight="bold" color="accent">
-              {t("embed.openFullConversation")}
-            </Typography>
-            <SvgIconArrowLink size="sm" className="text-orange-50" />
-          </Link>
-        </div>
-      </div>
-
-      <EmbedPageFooter
-        id={id}
-        modelName={thread.modelName}
-        fileCount={thread.fileCount}
-        viewCount={thread.viewCount}
-        likeCount={thread.likeCount}
-        messageCount={thread.messageCount}
-      />
+      <Suspense
+        fallback={
+          <div className="flex flex-col gap-4 px-4 pt-4">
+            <SkeletonBar className="h-5 w-2/3" />
+            <SkeletonBar className="h-24 w-full" />
+          </div>
+        }
+      >
+        <EmbedPageContent params={params} searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 };

--- a/app/src/app/(main)/auth/login/page.tsx
+++ b/app/src/app/(main)/auth/login/page.tsx
@@ -1,28 +1,15 @@
-import { redirect } from "next/navigation";
 import { Suspense } from "react";
-
-import { createClient } from "@/server/supabase/server";
 
 import { Container } from "@/components/ui/container";
 
-import { CliAuthLoginPageForm } from "@/components/cli-auth-login-page-form";
+import { AuthLoginPageContent } from "@/components/auth-login-page-content";
 import { CliAuthLoginPageFormSkeleton } from "@/components/cli-auth-login-page-form-skeleton";
 
-const AuthLoginPage = async () => {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (user) {
-    redirect("/");
-  }
-
+const AuthLoginPage = () => {
   return (
     <Container as="main" size="sm" spacing="md">
       <Suspense fallback={<CliAuthLoginPageFormSkeleton />}>
-        <CliAuthLoginPageForm />
+        <AuthLoginPageContent />
       </Suspense>
     </Container>
   );

--- a/app/src/app/(main)/cli/auth/page.tsx
+++ b/app/src/app/(main)/cli/auth/page.tsx
@@ -1,153 +1,23 @@
-import { isNil } from "ramda";
-import { redirect } from "next/navigation";
-import { isPast } from "date-fns";
-import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
-import { cliAuth } from "@/server/repos/cli-auth";
-import { createClient } from "@/server/supabase/server";
-import { createServiceClient } from "@/server/supabase/service";
-
-import { SvgIconClock } from "@/components/icon/svg-icon-clock";
-import { SvgIconKey } from "@/components/icon/svg-icon-key";
-import { SvgIconLock } from "@/components/icon/svg-icon-lock";
-import { SvgIconSkull } from "@/components/icon/svg-icon-skull";
 import { Container } from "@/components/ui/container";
-import { Typography } from "@/components/ui/typography";
 
 import { CliAuthPageHeader } from "@/components/cli-auth-page-header";
+import { CliAuthPageContent } from "@/components/cli-auth-page-content";
+import { CliAuthPageSkeleton } from "@/components/cli-auth-page-skeleton";
 
 type Props = {
   searchParams: Promise<{ code?: string }>;
 };
 
-const CliAuthPage = async ({ searchParams }: Props) => {
-  const t = await getTranslations();
-  const { code } = await searchParams;
-
-  if (isNil(code)) {
-    return (
-      <Container as="main" size="sm" spacing="md">
-        <div className="flex flex-col gap-12 md:gap-18">
-          <CliAuthPageHeader />
-          <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
-            <Typography variant="h4" className="flex items-center gap-2">
-              <SvgIconKey />
-              {t("cliAuth.invalidLinkTitle")}
-            </Typography>
-            <Typography color="neutral">{t("cliAuth.invalidLinkDescription")}</Typography>
-          </div>
-        </div>
-      </Container>
-    );
-  }
-
-  const serviceSupabase = createServiceClient();
-  const cliSession = await cliAuth.getByToken(serviceSupabase, code);
-
-  if (isNil(cliSession)) {
-    return (
-      <Container as="main" size="sm" spacing="md">
-        <div className="flex flex-col gap-12 md:gap-18">
-          <CliAuthPageHeader />
-          <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
-            <Typography variant="h4" className="flex items-center gap-2">
-              <SvgIconKey />
-              {t("cliAuth.invalidCodeTitle")}
-            </Typography>
-            <Typography color="neutral">{t("cliAuth.invalidCodeDescription")}</Typography>
-          </div>
-        </div>
-      </Container>
-    );
-  }
-
-  if (cliSession.completedAt) {
-    return (
-      <Container as="main" size="sm" spacing="md">
-        <div className="flex flex-col gap-12 md:gap-18">
-          <CliAuthPageHeader />
-          <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
-            <Typography variant="h4" className="flex items-center gap-2">
-              <SvgIconLock />
-              {t("cliAuth.successTitle")}
-            </Typography>
-            <Typography color="neutral">{t("cliAuth.successDescription")}</Typography>
-          </div>
-        </div>
-      </Container>
-    );
-  }
-
-  if (cliSession.expiresAt && isPast(cliSession.expiresAt)) {
-    return (
-      <Container as="main" size="sm" spacing="md">
-        <div className="flex flex-col gap-12 md:gap-18">
-          <CliAuthPageHeader />
-          <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
-            <Typography variant="h4" className="flex items-center gap-2">
-              <SvgIconClock />
-              {t("cliAuth.expiredTitle")}
-            </Typography>
-            <Typography color="neutral">{t("cliAuth.expiredDescription")}</Typography>
-          </div>
-        </div>
-      </Container>
-    );
-  }
-
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (isNil(user)) {
-    redirect(`/auth/login?redirect=${encodeURIComponent(`/cli/auth?code=${code}`)}`);
-  }
-
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (isNil(session)) {
-    redirect(`/auth/login?redirect=${encodeURIComponent(`/cli/auth?code=${code}`)}`);
-  }
-
-  try {
-    await cliAuth.complete(serviceSupabase, code, {
-      userId: session.user.id,
-      accessToken: session.access_token,
-      refreshToken: session.refresh_token,
-      completedAt: new Date().toISOString(),
-    });
-  } catch {
-    return (
-      <Container as="main" size="sm" spacing="md">
-        <div className="flex flex-col gap-12 md:gap-18">
-          <CliAuthPageHeader />
-          <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
-            <Typography variant="h4" className="flex items-center gap-2">
-              <SvgIconSkull />
-              {t("cliAuth.failedTitle")}
-            </Typography>
-            <Typography color="neutral">{t("cliAuth.failedDescription")}</Typography>
-          </div>
-        </div>
-      </Container>
-    );
-  }
-
+const CliAuthPage = ({ searchParams }: Props) => {
   return (
     <Container as="main" size="sm" spacing="md">
       <div className="flex flex-col gap-12 md:gap-18">
         <CliAuthPageHeader />
-        <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
-          <Typography variant="h4" className="flex items-center gap-2">
-            <SvgIconLock />
-            {t("cliAuth.successTitle")}
-          </Typography>
-          <Typography color="neutral">{t("cliAuth.successDescription")}</Typography>
-        </div>
+        <Suspense fallback={<CliAuthPageSkeleton />}>
+          <CliAuthPageContent searchParams={searchParams} />
+        </Suspense>
       </div>
     </Container>
   );

--- a/app/src/app/(main)/layout.tsx
+++ b/app/src/app/(main)/layout.tsx
@@ -1,4 +1,7 @@
+import { Suspense } from "react";
+
 import { AppBar } from "@/components/ui/app-bar";
+import { AppBarSkeleton } from "@/components/ui/app-bar-skeleton";
 import { Footer } from "@/components/ui/footer";
 import { Toaster } from "@/components/ui/sonner";
 
@@ -9,7 +12,9 @@ type MainLayoutProps = {
 const MainLayout = ({ children }: MainLayoutProps) => {
   return (
     <>
-      <AppBar />
+      <Suspense fallback={<AppBarSkeleton />}>
+        <AppBar />
+      </Suspense>
       <main>{children}</main>
       <Footer />
       <Toaster />

--- a/app/src/app/(main)/page.tsx
+++ b/app/src/app/(main)/page.tsx
@@ -1,19 +1,18 @@
-import { createClient } from "@/server/supabase/server";
-import { sessions } from "@/server/repos/sessions";
+import { Suspense } from "react";
 
 import { HomePageHeroIntroduction } from "@/components/home-page-hero-introduction";
-import { HomePageFeaturedThreadsCarousel } from "@/components/home-page-featured-threads-carousel";
 import { HomePageTutorialsList } from "@/components/home-page-tutorials-list";
+import { HomePageFeaturedThreadsDataLoader } from "@/components/home-page-featured-threads-data-loader";
+import { HomePageFeaturedThreadsSkeleton } from "@/components/home-page-featured-threads-skeleton";
 
-const HomePage = async () => {
-  const supabase = await createClient();
-  const threads = await sessions.getFeaturedThreads(supabase);
-
+const HomePage = () => {
   return (
     <div className="overflow-hidden [--util-grid-columns:10] md:[--util-grid-columns:20] lg:[--util-grid-columns:30]">
       <HomePageHeroIntroduction />
       <HomePageTutorialsList />
-      <HomePageFeaturedThreadsCarousel threads={threads} />
+      <Suspense fallback={<HomePageFeaturedThreadsSkeleton />}>
+        <HomePageFeaturedThreadsDataLoader />
+      </Suspense>
     </div>
   );
 };

--- a/app/src/app/(main)/profile/[username]/page.tsx
+++ b/app/src/app/(main)/profile/[username]/page.tsx
@@ -1,109 +1,24 @@
-import { Fragment } from "react";
-import { isEmpty, isNil } from "ramda";
-import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
-
-import { createClient } from "@/server/supabase/server";
-import { profiles } from "@/server/repos/profiles";
-import { sessions } from "@/server/repos/sessions";
-
-import { USER_PROFILE_THREADS_LIMIT } from "@/utils/constants";
-
-import { TrackingPixel } from "@/components/tracking-pixel";
-
-import { SvgIconLine } from "@/components/icon/svg-icon-line";
-import { SvgIconArrowRight } from "@/components/icon/svg-icon-arrow-right";
+import { Suspense } from "react";
 
 import { Container } from "@/components/ui/container";
-import { Typography } from "@/components/ui/typography";
-import { NavLabel, NavLink } from "@/components/ui/nav";
 
-import { ProfilePageThreadListItem } from "@/components/profile-page-thread-list-item";
-import { ProfilePageNoThreads } from "@/components/profile-page-no-threads";
-import { ProfilePageQuickStart } from "@/components/profile-page-quick-start";
-import { ProfilePageUserInfoSidebar } from "@/components/profile-page-user-info-sidebar";
-import { ProfilePageDangerZoneContainer } from "@/containers/profile-page-danger-zone-container";
+import { ProfilePageContent } from "@/components/profile-page-content";
+import { ProfilePageSkeleton } from "@/components/profile-page-skeleton";
 
 type ProfilePageProps = {
   params: Promise<{ username: string }>;
 };
 
-const ProfilePage = async ({ params }: ProfilePageProps) => {
-  const { username } = await params;
-
-  const t = await getTranslations();
-  const supabase = await createClient();
-  const profile = await profiles.getByUsername(supabase, username);
-
-  if (isNil(profile)) {
-    notFound();
-  }
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  const threads = await sessions.getByUserId(
-    supabase,
-    profile.id,
-    USER_PROFILE_THREADS_LIMIT,
-    user?.id,
-  );
-
-  const isOwner = user?.id === profile.id;
-
+const ProfilePage = ({ params }: ProfilePageProps) => {
   return (
-    <>
-      <Container
-        spacing="md"
-        className="grid grid-cols-1 items-start gap-12 lg:grid-cols-12 xl:gap-18"
-      >
-        <div className="col-span-1 lg:col-span-4">
-          <ProfilePageUserInfoSidebar
-            username={profile.username}
-            name={profile.name}
-            avatarUrl={profile.avatarUrl}
-            createdAt={new Date(profile.createdAt)}
-            threads={threads.length}
-            views={profile.viewCount}
-          />
-        </div>
-
-        <div className="col-span-1 grid grid-cols-1 lg:col-span-8">
-          <div className="col-span-12 flex justify-between border border-gray-250 p-4 md:p-8 lg:items-center">
-            <div className="flex items-center gap-3">
-              <SvgIconLine size="md" color="accent" />
-              <Typography variant="h4">{t("user.recentThreads")}</Typography>
-            </div>
-            <NavLink href="/threads">
-              <NavLabel>{t("user.seeAllThreads")}</NavLabel>
-              <SvgIconArrowRight size="sm" />
-            </NavLink>
-          </div>
-
-          <div className="flex flex-col gap-8">
-            {threads.length ? (
-              <div className="flex flex-col">
-                {threads.map((thread) => (
-                  <ProfilePageThreadListItem key={thread.id} thread={thread} />
-                ))}
-              </div>
-            ) : null}
-
-            {isEmpty(threads) ? (
-              <Fragment>
-                <ProfilePageNoThreads />
-                {isOwner ? <ProfilePageQuickStart /> : null}
-              </Fragment>
-            ) : null}
-
-            {isOwner ? <ProfilePageDangerZoneContainer /> : null}
-          </div>
-        </div>
-      </Container>
-
-      <TrackingPixel type="p" id={profile.id} />
-    </>
+    <Container
+      spacing="md"
+      className="grid grid-cols-1 items-start gap-12 lg:grid-cols-12 xl:gap-18"
+    >
+      <Suspense fallback={<ProfilePageSkeleton />}>
+        <ProfilePageContent params={params} />
+      </Suspense>
+    </Container>
   );
 };
 

--- a/app/src/app/(main)/threads/[id]/page.tsx
+++ b/app/src/app/(main)/threads/[id]/page.tsx
@@ -1,26 +1,13 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
 import { isNil } from "ramda";
-import { format } from "date-fns";
 
 import { getCachedThread } from "@/server/cache/thread";
 
 import copy from "@/copy/en-EN.json";
-import { getProjectName } from "@/utils/helpers";
 
-import { SvgIconArrowLeft } from "@/components/icon/svg-icon-arrow-left";
-import { Container } from "@/components/ui/container";
-import { NavLink, NavLabel } from "@/components/ui/nav";
-
-import { ThreadPageAuthorMeta } from "@/components/thread-page-author-meta";
 import { ThreadPageConversationSkeleton } from "@/components/thread-page-conversation-skeleton";
-import { ThreadPageSidebarContainer } from "@/containers/thread-page-sidebar-container";
-import { ThreadPageConversationContainer } from "@/containers/thread-page-conversation-container";
-
-import { ThreadEmbedProvider } from "@/context/thread-embed";
-import { TrackingPixel } from "@/components/tracking-pixel";
+import { ThreadPageContent } from "@/components/thread-page-content";
 
 type ThreadPageProps = {
   params: Promise<{ id: string }>;
@@ -54,60 +41,11 @@ export const generateMetadata = async ({
   };
 };
 
-const ThreadPage = async ({ params }: ThreadPageProps) => {
-  const { id } = await params;
-
-  const t = await getTranslations();
-  const thread = await getCachedThread(id);
-
-  if (isNil(thread)) {
-    notFound();
-  }
-
+const ThreadPage = ({ params }: ThreadPageProps) => {
   return (
-    <ThreadEmbedProvider>
-      <Container size="lg" spacing="none" className="grid grid-cols-1 lg:grid-cols-12">
-        <div className="col-span-1 flex flex-col gap-12 pt-9 pb-12 lg:col-span-9 lg:gap-18 lg:pb-0">
-          <div className="flex flex-col items-start gap-9">
-            <NavLink href="/threads">
-              <SvgIconArrowLeft size="sm" />
-              <NavLabel>{t("thread.backToThreads")}</NavLabel>
-            </NavLink>
-
-            <ThreadPageAuthorMeta
-              avatarUrl={thread.profiles?.avatarUrl}
-              username={thread.profiles?.username}
-              createdAt={thread.createdAt}
-              title={thread.title ?? t("common.untitled")}
-            />
-          </div>
-
-          <Suspense fallback={<ThreadPageConversationSkeleton />}>
-            <ThreadPageConversationContainer
-              id={thread.id}
-              avatarUrl={thread.profiles?.avatarUrl}
-              author={thread.profiles?.username ?? t("common.deactivated")}
-            />
-          </Suspense>
-        </div>
-
-        <div className="sticky top-0 col-span-1 flex flex-col justify-between self-start overflow-y-auto border-gray-250 border-t px-0 pt-12 lg:col-span-3 lg:h-screen lg:border-t-0 lg:border-l lg:px-6 lg:pt-24 lg:pb-12">
-          <ThreadPageSidebarContainer
-            id={thread.id}
-            isPublic={thread.isPublic}
-            userId={thread.userId}
-            createdAt={format(thread.createdAt, "MM/dd/yyyy")}
-            workingDir={getProjectName(thread.workingDir)}
-            modelName={thread.modelName}
-            fileCount={thread.fileCount}
-            viewCount={thread.viewCount}
-            likeCount={thread.likeCount}
-            messageCount={thread.messageCount}
-          />
-        </div>
-      </Container>
-      <TrackingPixel type="t" id={id} />
-    </ThreadEmbedProvider>
+    <Suspense fallback={<ThreadPageConversationSkeleton />}>
+      <ThreadPageContent params={params} />
+    </Suspense>
   );
 };
 

--- a/app/src/app/(main)/threads/page.tsx
+++ b/app/src/app/(main)/threads/page.tsx
@@ -1,14 +1,13 @@
+import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
-
-import { createClient } from "@/server/supabase/server";
-import { sessions } from "@/server/repos/sessions";
 
 import { gradient } from "@/utils/renderers";
 
 import { Container } from "@/components/ui/container";
 import { Typography } from "@/components/ui/typography";
 
-import { ThreadsPageThreadsContainer } from "@/containers/threads-page-threads-container";
+import { ThreadsPageDataLoader } from "@/components/threads-page-data-loader";
+import { ThreadsPageSkeleton } from "@/components/threads-page-skeleton";
 
 type ThreadsPageProps = {
   searchParams: Promise<{ query?: string }>;
@@ -16,10 +15,6 @@ type ThreadsPageProps = {
 
 const ThreadsPage = async ({ searchParams }: ThreadsPageProps) => {
   const t = await getTranslations();
-  const supabase = await createClient();
-
-  const { query } = await searchParams;
-  const { threads, total, nextOffset } = await sessions.getPublicThreads(supabase, { query });
 
   return (
     <Container size="md" spacing="md" className="flex flex-col gap-8">
@@ -32,12 +27,9 @@ const ThreadsPage = async ({ searchParams }: ThreadsPageProps) => {
         </Typography>
       </div>
 
-      <ThreadsPageThreadsContainer
-        initialQuery={query}
-        initialTotal={total}
-        initialNextOffset={nextOffset}
-        initialThreads={threads}
-      />
+      <Suspense fallback={<ThreadsPageSkeleton />}>
+        <ThreadsPageDataLoader searchParams={searchParams} />
+      </Suspense>
     </Container>
   );
 };

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -8,8 +8,6 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 
-import { createClient } from "@/server/supabase/server";
-
 import copy from "@/copy/en-EN.json";
 
 import { cn } from "@/utils/helpers";
@@ -43,18 +41,13 @@ export const metadata: Metadata = {
 const RootLayout = async ({ children }: RootLayoutProps) => {
   const locale = await getLocale();
   const messages = await getMessages();
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   return (
     <html lang={locale} className={cn(sans.variable, mono.variable)}>
       <body className="min-h-screen bg-fade bg-gray-100 font-sans text-white antialiased selection:bg-orange-50 selection:text-white">
         <QueryProvider>
           <NextIntlClientProvider messages={messages}>
-            <AuthProvider initialUser={user}>{children}</AuthProvider>
+            <AuthProvider>{children}</AuthProvider>
           </NextIntlClientProvider>
         </QueryProvider>
 

--- a/app/src/components/auth-login-page-content.tsx
+++ b/app/src/components/auth-login-page-content.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/server/supabase/server";
+
+import { CliAuthLoginPageForm } from "@/components/cli-auth-login-page-form";
+import { CliAuthLoginPageFormSkeleton } from "@/components/cli-auth-login-page-form-skeleton";
+
+const AuthLoginPageContent = async () => {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/");
+  }
+
+  return (
+    <Suspense fallback={<CliAuthLoginPageFormSkeleton />}>
+      <CliAuthLoginPageForm />
+    </Suspense>
+  );
+};
+
+export { AuthLoginPageContent };

--- a/app/src/components/cli-auth-page-content.tsx
+++ b/app/src/components/cli-auth-page-content.tsx
@@ -1,0 +1,123 @@
+import { isNil } from "ramda";
+import { redirect } from "next/navigation";
+import { isPast } from "date-fns";
+import { getTranslations } from "next-intl/server";
+
+import { cliAuth } from "@/server/repos/cli-auth";
+import { createClient } from "@/server/supabase/server";
+import { createServiceClient } from "@/server/supabase/service";
+
+import { SvgIconClock } from "@/components/icon/svg-icon-clock";
+import { SvgIconKey } from "@/components/icon/svg-icon-key";
+import { SvgIconLock } from "@/components/icon/svg-icon-lock";
+import { SvgIconSkull } from "@/components/icon/svg-icon-skull";
+import { Typography } from "@/components/ui/typography";
+
+type CliAuthPageContentProps = {
+  searchParams: Promise<{ code?: string }>;
+};
+
+const CliAuthPageContent = async ({ searchParams }: CliAuthPageContentProps) => {
+  const t = await getTranslations();
+  const { code } = await searchParams;
+
+  if (isNil(code)) {
+    return (
+      <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+        <Typography variant="h4" className="flex items-center gap-2">
+          <SvgIconKey />
+          {t("cliAuth.invalidLinkTitle")}
+        </Typography>
+        <Typography color="neutral">{t("cliAuth.invalidLinkDescription")}</Typography>
+      </div>
+    );
+  }
+
+  const serviceSupabase = createServiceClient();
+  const cliSession = await cliAuth.getByToken(serviceSupabase, code);
+
+  if (isNil(cliSession)) {
+    return (
+      <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+        <Typography variant="h4" className="flex items-center gap-2">
+          <SvgIconKey />
+          {t("cliAuth.invalidCodeTitle")}
+        </Typography>
+        <Typography color="neutral">{t("cliAuth.invalidCodeDescription")}</Typography>
+      </div>
+    );
+  }
+
+  if (cliSession.completedAt) {
+    return (
+      <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+        <Typography variant="h4" className="flex items-center gap-2">
+          <SvgIconLock />
+          {t("cliAuth.successTitle")}
+        </Typography>
+        <Typography color="neutral">{t("cliAuth.successDescription")}</Typography>
+      </div>
+    );
+  }
+
+  if (cliSession.expiresAt && isPast(cliSession.expiresAt)) {
+    return (
+      <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+        <Typography variant="h4" className="flex items-center gap-2">
+          <SvgIconClock />
+          {t("cliAuth.expiredTitle")}
+        </Typography>
+        <Typography color="neutral">{t("cliAuth.expiredDescription")}</Typography>
+      </div>
+    );
+  }
+
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (isNil(user)) {
+    redirect(`/auth/login?redirect=${encodeURIComponent(`/cli/auth?code=${code}`)}`);
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (isNil(session)) {
+    redirect(`/auth/login?redirect=${encodeURIComponent(`/cli/auth?code=${code}`)}`);
+  }
+
+  try {
+    await cliAuth.complete(serviceSupabase, code, {
+      userId: session.user.id,
+      accessToken: session.access_token,
+      refreshToken: session.refresh_token,
+      completedAt: new Date().toISOString(),
+    });
+  } catch {
+    return (
+      <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+        <Typography variant="h4" className="flex items-center gap-2">
+          <SvgIconSkull />
+          {t("cliAuth.failedTitle")}
+        </Typography>
+        <Typography color="neutral">{t("cliAuth.failedDescription")}</Typography>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+      <Typography variant="h4" className="flex items-center gap-2">
+        <SvgIconLock />
+        {t("cliAuth.successTitle")}
+      </Typography>
+      <Typography color="neutral">{t("cliAuth.successDescription")}</Typography>
+    </div>
+  );
+};
+
+export { CliAuthPageContent };

--- a/app/src/components/cli-auth-page-skeleton.tsx
+++ b/app/src/components/cli-auth-page-skeleton.tsx
@@ -1,0 +1,12 @@
+import { SkeletonBar } from "@/components/ui/skeleton";
+
+const CliAuthPageSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-3 border border-gray-500/40 px-8 py-8">
+      <SkeletonBar className="h-6 w-2/3" />
+      <SkeletonBar className="h-4 w-full" />
+    </div>
+  );
+};
+
+export { CliAuthPageSkeleton };

--- a/app/src/components/embed-page-content.tsx
+++ b/app/src/components/embed-page-content.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { isNil, not } from "ramda";
+
+import { createClient } from "@/server/supabase/server";
+import { sessions } from "@/server/repos/sessions";
+import { messages } from "@/server/repos/messages";
+
+import { compactConversation } from "@/utils/helpers";
+
+import { SvgIconArrowLink } from "@/components/icon/svg-icon-arrow-link";
+import { Typography } from "@/components/ui/typography";
+import { EmbedPageFooter } from "@/components/embed-page-footer";
+import { EmbedPageConversation } from "@/components/embed-page-conversation";
+
+type EmbedPageContentProps = {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string; to?: string }>;
+};
+
+const EmbedPageContent = async ({ params, searchParams }: EmbedPageContentProps) => {
+  const t = await getTranslations();
+
+  const { id } = await params;
+  const { from, to } = await searchParams;
+
+  if (isNil(from) || isNil(to)) {
+    notFound();
+  }
+
+  const fromId = Number.parseInt(from);
+  const toId = Number.parseInt(to);
+
+  if (Number.isNaN(fromId) || Number.isNaN(toId) || fromId > toId) {
+    notFound();
+  }
+
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const thread = await sessions.getByIdWithAuthor(supabase, id, user?.id);
+
+  if (isNil(thread)) {
+    notFound();
+  }
+  if (not(thread.isPublic) && thread.userId !== user?.id) {
+    notFound();
+  }
+
+  const result = await messages.getByRange(supabase, id, fromId, toId);
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 px-4 pt-4">
+        <Typography variant="body" fontWeight="semibold">
+          {thread.title}
+        </Typography>
+
+        <EmbedPageConversation
+          messages={compactConversation(result.messages)}
+          avatarUrl={thread.profiles?.avatarUrl}
+          author={thread.profiles?.username ?? t("common.deactivated")}
+        />
+
+        <div className="flex justify-end">
+          <Link href={`/threads/${id}`} target="_blank" className="flex items-center gap-3">
+            <Typography variant="small" fontWeight="bold" color="accent">
+              {t("embed.openFullConversation")}
+            </Typography>
+            <SvgIconArrowLink size="sm" className="text-orange-50" />
+          </Link>
+        </div>
+      </div>
+
+      <EmbedPageFooter
+        id={id}
+        modelName={thread.modelName}
+        fileCount={thread.fileCount}
+        viewCount={thread.viewCount}
+        likeCount={thread.likeCount}
+        messageCount={thread.messageCount}
+      />
+    </>
+  );
+};
+
+export { EmbedPageContent };

--- a/app/src/components/home-page-featured-threads-data-loader.tsx
+++ b/app/src/components/home-page-featured-threads-data-loader.tsx
@@ -1,0 +1,11 @@
+import { getCachedFeaturedThreads } from "@/server/cache/featured-threads";
+
+import { HomePageFeaturedThreadsCarousel } from "@/components/home-page-featured-threads-carousel";
+
+const HomePageFeaturedThreadsDataLoader = async () => {
+  const threads = await getCachedFeaturedThreads();
+
+  return <HomePageFeaturedThreadsCarousel threads={threads} />;
+};
+
+export { HomePageFeaturedThreadsDataLoader };

--- a/app/src/components/home-page-featured-threads-skeleton.tsx
+++ b/app/src/components/home-page-featured-threads-skeleton.tsx
@@ -1,0 +1,20 @@
+import { SkeletonBar } from "@/components/ui/skeleton";
+import { Container } from "@/components/ui/container";
+
+const HomePageFeaturedThreadsSkeleton = () => {
+  return (
+    <section className="flex flex-col gap-8 md:gap-12">
+      <Container size="lg" spacing="lg" className="flex flex-col">
+        <SkeletonBar className="h-8 w-1/3" />
+        <SkeletonBar className="h-5 w-2/3" />
+      </Container>
+      <div className="flex gap-4 overflow-hidden px-6">
+        <SkeletonBar className="h-48 w-80 shrink-0" />
+        <SkeletonBar className="h-48 w-80 shrink-0" />
+        <SkeletonBar className="h-48 w-80 shrink-0" />
+      </div>
+    </section>
+  );
+};
+
+export { HomePageFeaturedThreadsSkeleton };

--- a/app/src/components/profile-page-content.tsx
+++ b/app/src/components/profile-page-content.tsx
@@ -1,0 +1,104 @@
+import { Fragment } from "react";
+import { isEmpty, isNil } from "ramda";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { createClient } from "@/server/supabase/server";
+import { profiles } from "@/server/repos/profiles";
+import { sessions } from "@/server/repos/sessions";
+
+import { USER_PROFILE_THREADS_LIMIT } from "@/utils/constants";
+
+import { TrackingPixel } from "@/components/tracking-pixel";
+
+import { SvgIconLine } from "@/components/icon/svg-icon-line";
+import { SvgIconArrowRight } from "@/components/icon/svg-icon-arrow-right";
+
+import { Typography } from "@/components/ui/typography";
+import { NavLabel, NavLink } from "@/components/ui/nav";
+
+import { ProfilePageThreadListItem } from "@/components/profile-page-thread-list-item";
+import { ProfilePageNoThreads } from "@/components/profile-page-no-threads";
+import { ProfilePageQuickStart } from "@/components/profile-page-quick-start";
+import { ProfilePageUserInfoSidebar } from "@/components/profile-page-user-info-sidebar";
+import { ProfilePageDangerZoneContainer } from "@/containers/profile-page-danger-zone-container";
+
+type ProfilePageContentProps = {
+  params: Promise<{ username: string }>;
+};
+
+const ProfilePageContent = async ({ params }: ProfilePageContentProps) => {
+  const { username } = await params;
+
+  const t = await getTranslations();
+  const supabase = await createClient();
+  const profile = await profiles.getByUsername(supabase, username);
+
+  if (isNil(profile)) {
+    notFound();
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const threads = await sessions.getByUserId(
+    supabase,
+    profile.id,
+    USER_PROFILE_THREADS_LIMIT,
+    user?.id,
+  );
+
+  const isOwner = user?.id === profile.id;
+
+  return (
+    <>
+      <div className="col-span-1 lg:col-span-4">
+        <ProfilePageUserInfoSidebar
+          username={profile.username}
+          name={profile.name}
+          avatarUrl={profile.avatarUrl}
+          createdAt={new Date(profile.createdAt)}
+          threads={threads.length}
+          views={profile.viewCount}
+        />
+      </div>
+
+      <div className="col-span-1 grid grid-cols-1 lg:col-span-8">
+        <div className="col-span-12 flex justify-between border border-gray-250 p-4 md:p-8 lg:items-center">
+          <div className="flex items-center gap-3">
+            <SvgIconLine size="md" color="accent" />
+            <Typography variant="h4">{t("user.recentThreads")}</Typography>
+          </div>
+          <NavLink href="/threads">
+            <NavLabel>{t("user.seeAllThreads")}</NavLabel>
+            <SvgIconArrowRight size="sm" />
+          </NavLink>
+        </div>
+
+        <div className="flex flex-col gap-8">
+          {threads.length ? (
+            <div className="flex flex-col">
+              {threads.map((thread) => (
+                <ProfilePageThreadListItem key={thread.id} thread={thread} />
+              ))}
+            </div>
+          ) : null}
+
+          {isEmpty(threads) ? (
+            <Fragment>
+              <ProfilePageNoThreads />
+              {isOwner ? <ProfilePageQuickStart /> : null}
+            </Fragment>
+          ) : null}
+
+          {isOwner ? <ProfilePageDangerZoneContainer /> : null}
+        </div>
+      </div>
+
+      <TrackingPixel type="p" id={profile.id} />
+    </>
+  );
+};
+
+export { ProfilePageContent };

--- a/app/src/components/profile-page-skeleton.tsx
+++ b/app/src/components/profile-page-skeleton.tsx
@@ -1,0 +1,21 @@
+import { SkeletonAvatar, SkeletonBar } from "@/components/ui/skeleton";
+
+const ProfilePageSkeleton = () => {
+  return (
+    <div className="grid grid-cols-1 items-start gap-12 lg:grid-cols-12 xl:gap-18">
+      <div className="col-span-1 flex flex-col gap-6 lg:col-span-4">
+        <SkeletonAvatar className="size-16" />
+        <SkeletonBar className="h-6 w-2/3" />
+        <SkeletonBar className="h-4 w-1/2" />
+      </div>
+      <div className="col-span-1 flex flex-col gap-4 lg:col-span-8">
+        <SkeletonBar className="h-10 w-full" />
+        <SkeletonBar className="h-24 w-full" />
+        <SkeletonBar className="h-24 w-full" />
+        <SkeletonBar className="h-24 w-full" />
+      </div>
+    </div>
+  );
+};
+
+export { ProfilePageSkeleton };

--- a/app/src/components/thread-page-content.tsx
+++ b/app/src/components/thread-page-content.tsx
@@ -1,0 +1,84 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { isNil } from "ramda";
+import { format } from "date-fns";
+
+import { getCachedThread } from "@/server/cache/thread";
+
+import { getProjectName } from "@/utils/helpers";
+
+import { SvgIconArrowLeft } from "@/components/icon/svg-icon-arrow-left";
+import { Container } from "@/components/ui/container";
+import { NavLink, NavLabel } from "@/components/ui/nav";
+
+import { ThreadPageAuthorMeta } from "@/components/thread-page-author-meta";
+import { ThreadPageConversationSkeleton } from "@/components/thread-page-conversation-skeleton";
+import { ThreadPageSidebarContainer } from "@/containers/thread-page-sidebar-container";
+import { ThreadPageConversationContainer } from "@/containers/thread-page-conversation-container";
+
+import { ThreadEmbedProvider } from "@/context/thread-embed";
+import { TrackingPixel } from "@/components/tracking-pixel";
+
+type ThreadPageContentProps = {
+  params: Promise<{ id: string }>;
+};
+
+const ThreadPageContent = async ({ params }: ThreadPageContentProps) => {
+  const { id } = await params;
+
+  const t = await getTranslations();
+  const thread = await getCachedThread(id);
+
+  if (isNil(thread)) {
+    notFound();
+  }
+
+  return (
+    <ThreadEmbedProvider>
+      <Container size="lg" spacing="none" className="grid grid-cols-1 lg:grid-cols-12">
+        <div className="col-span-1 flex flex-col gap-12 pt-9 pb-12 lg:col-span-9 lg:gap-18 lg:pb-0">
+          <div className="flex flex-col items-start gap-9">
+            <NavLink href="/threads">
+              <SvgIconArrowLeft size="sm" />
+              <NavLabel>{t("thread.backToThreads")}</NavLabel>
+            </NavLink>
+
+            <ThreadPageAuthorMeta
+              avatarUrl={thread.profiles?.avatarUrl}
+              username={thread.profiles?.username}
+              createdAt={thread.createdAt}
+              title={thread.title ?? t("common.untitled")}
+            />
+          </div>
+
+          <Suspense fallback={<ThreadPageConversationSkeleton />}>
+            <ThreadPageConversationContainer
+              id={thread.id}
+              avatarUrl={thread.profiles?.avatarUrl}
+              author={thread.profiles?.username ?? t("common.deactivated")}
+            />
+          </Suspense>
+        </div>
+
+        <div className="sticky top-0 col-span-1 flex flex-col justify-between self-start overflow-y-auto border-gray-250 border-t px-0 pt-12 lg:col-span-3 lg:h-screen lg:border-t-0 lg:border-l lg:px-6 lg:pt-24 lg:pb-12">
+          <ThreadPageSidebarContainer
+            id={thread.id}
+            isPublic={thread.isPublic}
+            userId={thread.userId}
+            createdAt={format(thread.createdAt, "MM/dd/yyyy")}
+            workingDir={getProjectName(thread.workingDir)}
+            modelName={thread.modelName}
+            fileCount={thread.fileCount}
+            viewCount={thread.viewCount}
+            likeCount={thread.likeCount}
+            messageCount={thread.messageCount}
+          />
+        </div>
+      </Container>
+      <TrackingPixel type="t" id={id} />
+    </ThreadEmbedProvider>
+  );
+};
+
+export { ThreadPageContent };

--- a/app/src/components/threads-page-data-loader.tsx
+++ b/app/src/components/threads-page-data-loader.tsx
@@ -1,0 +1,25 @@
+import { createClient } from "@/server/supabase/server";
+import { sessions } from "@/server/repos/sessions";
+
+import { ThreadsPageThreadsContainer } from "@/containers/threads-page-threads-container";
+
+type ThreadsPageDataLoaderProps = {
+  searchParams: Promise<{ query?: string }>;
+};
+
+const ThreadsPageDataLoader = async ({ searchParams }: ThreadsPageDataLoaderProps) => {
+  const { query } = await searchParams;
+  const supabase = await createClient();
+  const { threads, total, nextOffset } = await sessions.getPublicThreads(supabase, { query });
+
+  return (
+    <ThreadsPageThreadsContainer
+      initialQuery={query}
+      initialTotal={total}
+      initialNextOffset={nextOffset}
+      initialThreads={threads}
+    />
+  );
+};
+
+export { ThreadsPageDataLoader };

--- a/app/src/components/threads-page-skeleton.tsx
+++ b/app/src/components/threads-page-skeleton.tsx
@@ -1,0 +1,16 @@
+import { SkeletonBar } from "@/components/ui/skeleton";
+
+const ThreadsPageSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-6">
+      <SkeletonBar className="h-10 w-full" />
+      <div className="flex flex-col gap-4">
+        <SkeletonBar className="h-24 w-full" />
+        <SkeletonBar className="h-24 w-full" />
+        <SkeletonBar className="h-24 w-full" />
+      </div>
+    </div>
+  );
+};
+
+export { ThreadsPageSkeleton };

--- a/app/src/components/ui/app-bar-skeleton.tsx
+++ b/app/src/components/ui/app-bar-skeleton.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+import { SvgIconClaudebinXs } from "@/components/icon/svg-icon-claudebin-xs";
+import { Container } from "@/components/ui/container";
+import { Divider } from "@/components/ui/divider";
+
+// ABOUTME: Static skeleton for AppBar during Suspense — renders logo and divider
+// without dynamic hooks (usePathname, useAuth) that would break cacheComponents prerender
+const AppBarSkeleton = () => {
+  return (
+    <header data-slot="app-bar" className="sticky top-0 z-50">
+      <Container size="lg">
+        <div className="flex items-center justify-between pt-3 pb-2">
+          <Link href="/" className="transition-colors ease-in-out hover:text-orange-50">
+            <SvgIconClaudebinXs size="auto" className="w-14" />
+          </Link>
+        </div>
+        <Divider />
+      </Container>
+    </header>
+  );
+};
+
+export { AppBarSkeleton };

--- a/app/src/context/auth.tsx
+++ b/app/src/context/auth.tsx
@@ -15,15 +15,18 @@ const AuthContext = createContext<AuthContextValue>({
 });
 
 type AuthProviderProps = {
-  initialUser: User | null;
   children: React.ReactNode;
 };
 
-const AuthProvider = ({ initialUser, children }: AuthProviderProps) => {
-  const [user, setUser] = useState<User | null>(initialUser);
+const AuthProvider = ({ children }: AuthProviderProps) => {
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
     const supabase = createClient();
+
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user);
+    });
 
     const {
       data: { subscription },

--- a/app/src/server/cache/featured-threads.ts
+++ b/app/src/server/cache/featured-threads.ts
@@ -1,0 +1,14 @@
+import { connection } from "next/server";
+
+import { createServiceClient } from "@/server/supabase/service";
+import { sessions } from "@/server/repos/sessions";
+
+// ABOUTME: Featured threads fetch — bypasses RLS via service client
+// Returns public featured threads for the home page carousel
+// Uses connection() to defer to request time inside Suspense boundary
+export const getCachedFeaturedThreads = async () => {
+  await connection();
+
+  const supabase = createServiceClient();
+  return sessions.getFeaturedThreads(supabase);
+};


### PR DESCRIPTION
## Summary

- Enable `cacheComponents: true` and remove legacy `dynamicIO: false` from Next.js config
- Move auth from server-side root layout to client-side `AuthProvider` (fetches user in `useEffect`)
- Wrap `AppBar` in Suspense in `(main)` layout to handle `usePathname()` dynamic access
- Extract page content into Suspense-wrapped async server components for all pages with dynamic data: threads list, thread detail, CLI auth, auth login, profile, and embed
- Add skeleton fallback components for streaming UI during partial prerendering

## Test plan

- [x] `bun build` succeeds with `cacheComponents: true` (18/18 pages, partial prerender working)
- [x] `bun type-check` passes
- [x] `bun check` (biome) passes
- [ ] Verify `/` loads with hero + tutorials immediately, carousel streams in
- [ ] Verify `/threads` heading renders immediately, thread list streams in
- [ ] Verify `/threads/[id]` thread metadata streams, conversation streams
- [ ] Verify `/cli/auth` header renders, content streams
- [ ] Verify `/auth/login` form loads, logged-in users redirect
- [ ] Verify `/profile/[username]` profile loads, owner features work
- [ ] Verify AppBar shows login/profile correctly after client-side auth hydration

## Session

🤖 [Claude Code session](https://claudebin.com/threads/Eg34p28Faq)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)