### PR TITLE
fix: render local CLI commands as distinct block type

### DIFF
--- a/app/src/components/thread-page-conversation-local-command.tsx
+++ b/app/src/components/thread-page-conversation-local-command.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { isServer } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { useMediaQuery } from "usehooks-ts";
+
+import type { LocalCommandBlock } from "@/supabase/types/message";
+
+import { mediaQueries } from "@/utils/media-queries";
+
+import { SvgIconBash } from "@/components/icon/svg-icon-bash";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Code } from "@/components/ui/code";
+
+import { ThreadPageConversationChip } from "@/components/thread-page-conversation-chip";
+
+type ThreadPageConversationLocalCommandProps = {
+  block: LocalCommandBlock;
+};
+
+const ThreadPageConversationLocalCommand = ({ block }: ThreadPageConversationLocalCommandProps) => {
+  const t = useTranslations();
+  const md = useMediaQuery(mediaQueries.md, { initializeWithValue: isServer });
+
+  if (!block.output) {
+    return (
+      <div className="flex items-center gap-2 py-2">
+        <SvgIconBash size="sm" color="primary" />
+        <span className="text-primary text-sm">{t("chat.command")}</span>
+        <ThreadPageConversationChip label={block.commandName} />
+      </div>
+    );
+  }
+
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="local-command">
+        <AccordionTrigger>
+          <SvgIconBash size="sm" color="primary" />
+          {t("chat.command")}
+          {md ? <ThreadPageConversationChip label={block.commandName} /> : null}
+        </AccordionTrigger>
+
+        <AccordionContent>
+          {md ? null : <ThreadPageConversationChip label={block.commandName} />}
+          <Code code={block.output} />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export { ThreadPageConversationLocalCommand };

--- a/app/src/copy/en-EN.json
+++ b/app/src/copy/en-EN.json
@@ -160,6 +160,7 @@
     "mcp": "MCP",
     "mcpLabel": "{server} / {tool}",
     "skill": "Skill",
+    "command": "Command",
     "bytes": "Bytes",
     "error": "Error"
   },

--- a/app/src/server/services/parser/pipeline.ts
+++ b/app/src/server/services/parser/pipeline.ts
@@ -7,6 +7,8 @@ import {
   MessageRole,
   parseSkillCommand,
   parseSkillMeta,
+  isLocalCommandOutput,
+  parseLocalCommandOutput,
   type SkillCommandData,
 } from "@/supabase/types/message";
 
@@ -86,6 +88,7 @@ export const createPipeline = () => {
     msg.blocks.flatMap((b) => {
       if (b.type === BlockType.TEXT) return [(b as { text: string }).text];
       if (b.type === BlockType.SKILL) return [(b as { name: string }).name];
+      if (b.type === BlockType.LOCAL_COMMAND) return [(b as { name: string }).name];
       return [];
     });
 
@@ -215,14 +218,25 @@ export const createPipeline = () => {
     if (!pipeline.pendingSkillCommand) return;
 
     const text = typeof content === "string" ? content : extractText(content);
-    const skillMeta = parseSkillMeta(text);
     resetMessageState();
-    emit({
-      type: BlockType.SKILL,
-      ...pipeline.pendingSkillCommand,
-      instructions: skillMeta.instructions,
-      output: skillMeta.output,
-    });
+
+    if (isLocalCommandOutput(text)) {
+      const { output } = parseLocalCommandOutput(text);
+      emit({
+        type: BlockType.LOCAL_COMMAND,
+        ...pipeline.pendingSkillCommand,
+        output,
+      });
+    } else {
+      const skillMeta = parseSkillMeta(text);
+      emit({
+        type: BlockType.SKILL,
+        ...pipeline.pendingSkillCommand,
+        instructions: skillMeta.instructions,
+        output: skillMeta.output,
+      });
+    }
+
     pipeline.pendingSkillCommand = null;
   };
 
@@ -260,13 +274,25 @@ export const createPipeline = () => {
     if (!content) return false;
 
     if (isMeta && pipeline.pendingSkillCommand) {
-      const skillMeta = parseSkillMeta(extractText(content));
-      emit({
-        type: BlockType.SKILL,
-        ...pipeline.pendingSkillCommand,
-        instructions: skillMeta.instructions,
-        output: skillMeta.output,
-      });
+      const text = extractText(content);
+
+      if (isLocalCommandOutput(text)) {
+        const { output } = parseLocalCommandOutput(text);
+        emit({
+          type: BlockType.LOCAL_COMMAND,
+          ...pipeline.pendingSkillCommand,
+          output,
+        });
+      } else {
+        const skillMeta = parseSkillMeta(text);
+        emit({
+          type: BlockType.SKILL,
+          ...pipeline.pendingSkillCommand,
+          instructions: skillMeta.instructions,
+          output: skillMeta.output,
+        });
+      }
+
       pipeline.pendingSkillCommand = null;
       return true;
     }

--- a/app/src/supabase/types/message.ts
+++ b/app/src/supabase/types/message.ts
@@ -24,6 +24,7 @@ export const BlockType = {
   WEB_SEARCH: "web_search",
   TASKS: "tasks",
   SKILL: "skill",
+  LOCAL_COMMAND: "local_command",
 } as const;
 
 export type Block = (typeof BlockType)[keyof typeof BlockType];
@@ -46,7 +47,8 @@ export type ContentBlock =
   | WebFetchBlock
   | WebSearchBlock
   | TasksBlock
-  | SkillBlock;
+  | SkillBlock
+  | LocalCommandBlock;
 
 export type ImageAttachment = {
   type: "image";
@@ -248,6 +250,13 @@ export interface SkillBlock {
   output?: string;
 }
 
+export interface LocalCommandBlock {
+  type: typeof BlockType.LOCAL_COMMAND;
+  name: string;
+  commandName: string;
+  output?: string;
+}
+
 export enum RawTool {
   ASK_USER_QUESTION = "AskUserQuestion",
   BASH = "Bash",
@@ -332,3 +341,16 @@ export const parseSkillMeta = (content: string): SkillMetaData => {
   const trimmed = content.trim();
   return trimmed ? { instructions: trimmed } : {};
 };
+
+// Local command patterns
+const LOCAL_COMMAND_STDOUT_REGEX = /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/;
+
+export const parseLocalCommandOutput = (content: string): { output?: string } => {
+  const match = content.match(LOCAL_COMMAND_STDOUT_REGEX);
+  if (!match) return {};
+  const trimmed = match[1]?.trim();
+  return trimmed ? { output: trimmed } : {};
+};
+
+export const isLocalCommandOutput = (content: string): boolean =>
+  LOCAL_COMMAND_STDOUT_REGEX.test(content);

--- a/app/src/utils/renderers.tsx
+++ b/app/src/utils/renderers.tsx
@@ -20,6 +20,7 @@ import { ThreadPageConversationWebSearch } from "@/components/thread-page-conver
 import { ThreadPageConversationMcp } from "@/components/thread-page-conversation-mcp";
 import { ThreadPageConversationGeneric } from "@/components/thread-page-conversation-generic";
 import { ThreadPageConversationSkill } from "@/components/thread-page-conversation-skill";
+import { ThreadPageConversationLocalCommand } from "@/components/thread-page-conversation-local-command";
 
 export const gradient = (chunks: ReactNode) => (
   <span className="inline-block bg-linear-to-r from-orange-200 to-orange-50 bg-clip-text text-transparent">
@@ -63,6 +64,8 @@ export const block = (content: ContentBlock, index: number): ReactNode => {
       return <ThreadPageConversationGeneric key={index} block={content} />;
     case BlockType.SKILL:
       return <ThreadPageConversationSkill key={index} block={content} />;
+    case BlockType.LOCAL_COMMAND:
+      return <ThreadPageConversationLocalCommand key={index} block={content} />;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- Adds `LOCAL_COMMAND` block type with its own parser for `<local-command-stdout>` tags
- Routes local commands (`/clear`, `/help`, `/compact`) away from the skill parser in the pipeline
- New `ThreadPageConversationLocalCommand` component with bash icon and "Command" label
- Simple pill when no output, accordion with code block when output exists

Closes #41

## Session

[claudebin.com/threads/AL-X1ypTWK](https://claudebin.com/threads/AL-X1ypTWK)

## Test plan

- [ ] Visit `/threads/7-WzkqtrK6` — `/clear` should render as "Command /clear" pill with bash icon
- [ ] `bun check` passes
- [ ] `bun type-check` passes (only pre-existing layout.tsx errors)
- [ ] Sessions with `/help`, `/compact` render correctly
- [ ] Skill blocks (`/commit`, custom skills) still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)