### PR TITLE
feat: add data caching for threads, messages, and featured threads

### DIFF
--- a/app/src/server/actions/like.ts
+++ b/app/src/server/actions/like.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { isNil } from "ramda";
+import { revalidateTag } from "next/cache";
 
 import { createClient } from "@/server/supabase/server";
 import { sessionLikes } from "@/server/repos/sessionLikes";
@@ -32,6 +33,7 @@ export const like = async (sessionId: string) => {
 
   const result = await sessionLikes.toggle(supabase, sessionId, user.id);
 
-  // TODO: Re-add revalidateTag once cacheComponents is re-enabled
+  revalidateTag(`thread-${sessionId}`, { expire: 0 });
+
   return result;
 };

--- a/app/src/server/actions/threads.ts
+++ b/app/src/server/actions/threads.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { isNil } from "ramda";
+import { revalidateTag } from "next/cache";
 
 import { createClient } from "@/server/supabase/server";
 import { sessions, type GetPublicThreadsResult } from "@/server/repos/sessions";
@@ -40,7 +41,8 @@ export const deleteThread = async (sessionId: string) => {
 
   await sessions.delete(supabase, sessionId);
 
-  // TODO: Re-add revalidateTag once cacheComponents is re-enabled
+  revalidateTag(`thread-${sessionId}`, { expire: 0 });
+
   if (session.storagePath) {
     await sessions.deleteFile(supabase, session.storagePath);
   }

--- a/app/src/server/actions/visibility.ts
+++ b/app/src/server/actions/visibility.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { not, isNil } from "ramda";
+import { revalidateTag } from "next/cache";
 
 import { createClient } from "@/server/supabase/server";
 import { sessions } from "@/server/repos/sessions";
@@ -26,7 +27,8 @@ export const toggleVisibility = async (sessionId: string) => {
     isPublic: not(session.isPublic),
   });
 
-  // TODO: Re-add revalidateTag once cacheComponents is re-enabled
+  revalidateTag(`thread-${sessionId}`, { expire: 0 });
+
   return {
     isPublic: not(session.isPublic),
   };

--- a/app/src/server/cache/featured-threads.ts
+++ b/app/src/server/cache/featured-threads.ts
@@ -1,10 +1,17 @@
+import { unstable_cache } from "next/cache";
+
 import { createServiceClient } from "@/server/supabase/service";
 import { sessions } from "@/server/repos/sessions";
 
-// ABOUTME: Featured threads fetch — bypasses RLS via service client
+// ABOUTME: Featured threads fetch — bypasses RLS via service client, cached with on-demand revalidation
 // Returns public featured threads for the home page carousel
-// TODO: Re-add "use cache" caching once cacheComponents is stable
-export const getCachedFeaturedThreads = async () => {
-  const supabase = createServiceClient();
-  return sessions.getFeaturedThreads(supabase);
-};
+// Invalidated via revalidateTag("featured-threads") when featured list changes
+export const getCachedFeaturedThreads = () =>
+  unstable_cache(
+    async () => {
+      const supabase = createServiceClient();
+      return sessions.getFeaturedThreads(supabase);
+    },
+    ["featured-threads"],
+    { tags: ["featured-threads"] },
+  )();

--- a/app/src/server/cache/messages.ts
+++ b/app/src/server/cache/messages.ts
@@ -1,10 +1,16 @@
+import { unstable_cache } from "next/cache";
+
 import { createServiceClient } from "@/server/supabase/service";
 import { messages, type PaginatedMessages } from "@/server/repos/messages";
 
 // ABOUTME: Messages fetch — messages are immutable after session processing
 // Uses service client to bypass RLS (access control happens at page level)
-// TODO: Re-add "use cache" caching once cacheComponents is stable
-export const getCachedMessages = async (sessionId: string): Promise<PaginatedMessages> => {
-  const supabase = createServiceClient();
-  return messages.getBySessionId(supabase, sessionId);
-};
+// Cached indefinitely — messages never change after processing
+export const getCachedMessages = (sessionId: string): Promise<PaginatedMessages> =>
+  unstable_cache(
+    async () => {
+      const supabase = createServiceClient();
+      return messages.getBySessionId(supabase, sessionId);
+    },
+    ["messages", sessionId],
+  )();

--- a/app/src/server/cache/thread.ts
+++ b/app/src/server/cache/thread.ts
@@ -1,11 +1,18 @@
+import { unstable_cache } from "next/cache";
+
 import { createServiceClient } from "@/server/supabase/service";
 import { sessions } from "@/server/repos/sessions";
 
-// ABOUTME: Thread data fetch — bypasses RLS via service client
+// ABOUTME: Thread data fetch — bypasses RLS via service client, cached with on-demand revalidation
 // Returns thread + author profile without like status (hasLiked is fetched client-side)
 // Private threads are returned too — access control happens in the page component
-// TODO: Re-add "use cache" caching once cacheComponents is stable
-export const getCachedThread = async (id: string) => {
-  const supabase = createServiceClient();
-  return sessions.getByIdWithProfile(supabase, id);
-};
+// Invalidated via revalidateTag("thread-{id}") when likes or visibility change
+export const getCachedThread = (id: string) =>
+  unstable_cache(
+    async () => {
+      const supabase = createServiceClient();
+      return sessions.getByIdWithProfile(supabase, id);
+    },
+    ["thread", id],
+    { tags: [`thread-${id}`] },
+  )();


### PR DESCRIPTION
## Summary

- Cache Supabase queries using `unstable_cache` (Next.js Data Cache) with on-demand revalidation via tags
- No rendering model changes — pages stay dynamic, no Suspense boundaries, no `cacheComponents`
- Wire up `revalidateTag` in mutation server actions (like, visibility toggle, delete)

**Cache layer:**
- `getCachedThread` — cached per thread ID, tagged `thread-{id}`
- `getCachedMessages` — cached per session, no tags (immutable data)
- `getCachedFeaturedThreads` — cached with tag `featured-threads`

**Revalidation:**
- `like()` → `revalidateTag("thread-{id}")`
- `toggleVisibility()` → `revalidateTag("thread-{id}")`
- `deleteThread()` → `revalidateTag("thread-{id}")`

## Test plan

- [ ] Verify thread page loads correctly and subsequent visits serve cached data
- [ ] Verify messages load correctly and are cached (immutable)
- [ ] Verify featured threads carousel loads from cache on homepage
- [ ] Verify liking a thread invalidates the thread cache (like count updates on next visit)
- [ ] Verify toggling visibility invalidates the thread cache
- [ ] Verify deleting a thread invalidates the thread cache
- [ ] `bun run build` passes
- [ ] `bun run lint` passes

## Session

🤖 [Claude Code session](https://claudebin.com/threads/a_1nQdkwk6)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)