### PR TITLE
fix: handle indented whitespace in local command tags

### DIFF
--- a/app/src/server/services/parser/localCommand.test.ts
+++ b/app/src/server/services/parser/localCommand.test.ts
@@ -22,6 +22,13 @@ describe("parseLocalCommand", () => {
     expect(result).toEqual({ name: "compact", commandName: "/compact" });
   });
 
+  test("parses local command with indented whitespace between tags", () => {
+    const content =
+      "<command-name>/clear</command-name>\n            <command-message>clear</command-message>\n            <command-args></command-args>";
+    const result = parseLocalCommand(content);
+    expect(result).toEqual({ name: "clear", commandName: "/clear" });
+  });
+
   test("returns null for skill command format", () => {
     const content =
       "<command-message>claudebin:share</command-message>\n<command-name>/claudebin:share</command-name>";

--- a/app/src/supabase/types/message.ts
+++ b/app/src/supabase/types/message.ts
@@ -347,7 +347,7 @@ export const parseSkillMeta = (content: string): SkillMetaData => {
 // Local:  <command-name>/clear</command-name>\n<command-message>clear</command-message>
 // Skill:  <command-message>name</command-message>\n<command-name>/name</command-name>
 const LOCAL_COMMAND_REGEX =
-  /<command-name>\/([^<]+)<\/command-name>\s*\n<command-message>([^<]+)<\/command-message>/;
+  /<command-name>\/([^<]+)<\/command-name>\s+<command-message>([^<]+)<\/command-message>/;
 const LOCAL_COMMAND_STDOUT_REGEX = /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/;
 const LOCAL_COMMAND_CAVEAT_REGEX = /<local-command-caveat>[\s\S]*?<\/local-command-caveat>/;
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #62 — the regex used `\s*\n` which only matched newline without trailing spaces
- Real JSONL has `\n            ` (newline + 12 spaces) between tags, causing the regex to miss every local command
- Changed regex from `\s*\n` to `\s+` to match any whitespace between tags

## Test plan
- [x] Added test with real indented format from production JSONL
- [x] All 45 parser tests pass
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)