### PR TITLE
fix: exclude video files from auth middleware matcher

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -66,6 +66,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * - public folder
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webm|mp4)$).*)",
   ],
 };


### PR DESCRIPTION
.webm and .mp4 were not in the middleware matcher exclusion list, causing video requests to hit the auth check and redirect to login.

## Summary

Brief description of changes.

## Changes

- Change 1
- Change 2

## Claudebin Session

<!-- Paste the claudebin.com link to the session used for this PR -->

🔗 [Session Link](https://claudebin.com/threads/...)

## Testing

How did you test this?

## Checklist

- [ ] `bun check` passes
- [ ] `bun type-check` passes
- [ ] Tested locally
- [ ] Claudebin session link attached
