### PR TITLE
fix: protect system-managed columns from direct modification (AIS-FED-CLA-012)

### DIFF
--- a/supabase/migrations/20260301000001_protect_system_columns.sql
+++ b/supabase/migrations/20260301000001_protect_system_columns.sql
@@ -1,5 +1,5 @@
 -- ABOUTME: Prevents authenticated users from directly modifying system-managed columns
--- ABOUTME: SECURITY DEFINER functions (track_page_view, update_session_like_count) bypass this trigger
+-- ABOUTME: Uses current_user so SECURITY DEFINER functions naturally bypass this trigger
 
 -- Shared trigger function: raises 42501 (insufficient_privilege) -> PostgREST returns HTTP 403
 CREATE FUNCTION reject_system_column_update()
@@ -16,7 +16,7 @@ CREATE TRIGGER protect_sessions_system_columns
   BEFORE UPDATE ON sessions
   FOR EACH ROW
   WHEN (
-    current_setting('role') = 'authenticated'
+    current_user = 'authenticated'
     AND (
       NEW."viewCount"    IS DISTINCT FROM OLD."viewCount"
       OR NEW."likeCount"    IS DISTINCT FROM OLD."likeCount"
@@ -36,7 +36,7 @@ CREATE TRIGGER protect_profiles_system_columns
   BEFORE UPDATE ON profiles
   FOR EACH ROW
   WHEN (
-    current_setting('role') = 'authenticated'
+    current_user = 'authenticated'
     AND (
       NEW."viewCount"  IS DISTINCT FROM OLD."viewCount"
       OR NEW."createdAt"  IS DISTINCT FROM OLD."createdAt"


### PR DESCRIPTION
## SUMMARY
Security issue detected and fixed by [AISafe Labs](https://aisafe.io) autonomous Source code audit service.
- Issue title: **Unauthorized Data Modification in Sessions**
- Issue ID: `AIS-FED-CLA-012`

## TECHNICAL DETAILS
**Description:**
The sessions table's RLS UPDATE policy only checks ownership (`auth.uid() = "userId"`) but does not restrict which columns can be modified. This means any session owner can send a direct `PATCH` request to the PostgREST API and overwrite system-managed columns: `viewCount`, `likeCount`, `isFeatured`, `status`, `storagePath`, `errorMessage`, `fileCount`, and `messageCount`, to arbitrary values.

**Root cause:**
PostgREST exposes column-level writes for any column permitted by RLS, and PostgreSQL RLS policies cannot restrict updates to specific columns. The policy grants blanket UPDATE access to the entire row.

**Impact:**
- **Featured thread hijacking:** a user can set `isFeatured = true` on their own session, injecting it into the Featured Threads homepage carousel and bypassing administrative curation.
- **Engagement metric forgery:** `viewCount` and `likeCount` can be set to arbitrary values, undermining trust in all public engagement signals.
- **State corruption:** `status`, `storagePath`, `errorMessage`, `fileCount`, and `messageCount` can be overwritten, potentially breaking session rendering or upload workflows.

**Fix:**
A BEFORE UPDATE trigger (`protect_sessions_system_columns`) now rejects any authenticated-role update that attempts to modify a protected column, returning `HTTP 403`. The trigger uses `current_user` (rather than `current_setting('role')`) so that `SECURITY DEFINER` functions like `update_session_like_count` and `track_page_view` naturally bypass it. An equivalent trigger protects `viewCount` and `createdAt` on the profiles table.

## PROOF OF CONCEPT
![poc1](https://github.com/user-attachments/assets/b2caca60-d61a-4fb8-b716-f321b2077128)
![poc2](https://github.com/user-attachments/assets/ec098fcf-d8e7-455e-b089-6df887a3cefe)

[Session link](https://claudebin.com/threads/6Ds0hFZu1i)