### PR TITLE
fix(a11y): add accessible names to icon-only buttons

### DIFF
--- a/app/src/components/home-page-featured-threads-carousel.tsx
+++ b/app/src/components/home-page-featured-threads-carousel.tsx
@@ -49,10 +49,14 @@ const HomePageFeaturedThreadsCarousel = ({
           </Typography>
 
           <div className="flex items-center gap-2">
-            <Button variant="icon" onClick={handlePrev}>
+            <Button
+              variant="icon"
+              onClick={handlePrev}
+              aria-label={t("home.featuredThreadsPrevious")}
+            >
               <SvgIconArrowLeft />
             </Button>
-            <Button variant="icon" onClick={handleNext}>
+            <Button variant="icon" onClick={handleNext} aria-label={t("home.featuredThreadsNext")}>
               <SvgIconArrowRight />
             </Button>
           </div>

--- a/app/src/components/ui/card.tsx
+++ b/app/src/components/ui/card.tsx
@@ -176,20 +176,20 @@ const cardActionsVariantClassNames: CardVariantMapping = {
   grid: "absolute top-3 right-3",
 } as const;
 
-type CardActionsProps = Omit<React.ComponentProps<"button">, "children">;
+type CardActionsProps = Omit<React.ComponentProps<"span">, "children">;
 
 const CardActions = ({ className, ...props }: CardActionsProps) => {
   const variant = useContext(CardContext);
 
   return (
-    <button
-      type="button"
+    <span
       data-slot="card-actions"
-      className={cn("cursor-pointer", cardActionsVariantClassNames[variant], className)}
+      aria-hidden="true"
+      className={cn("inline-flex", cardActionsVariantClassNames[variant], className)}
       {...props}
     >
       <SvgIconArrowLink size="sm" color="accent" />
-    </button>
+    </span>
   );
 };
 

--- a/app/src/copy/en-EN.json
+++ b/app/src/copy/en-EN.json
@@ -58,6 +58,8 @@
     "howToUse": "How to Use",
     "featuredThreadsTitle": "/Featured <gradient>threads</gradient>",
     "featuredThreadsDescription": "Handpicked conversations worth exploring.",
+    "featuredThreadsPrevious": "Show previous featured threads",
+    "featuredThreadsNext": "Show next featured threads",
     "seeMoreThreads": "See more threads"
   },
   "error": {


### PR DESCRIPTION
Lighthouse flagged five buttons with no accessible name in the home page featured threads section. Screen readers were announcing them as just "button".

- Carousel prev/next buttons: add aria-label via i18n (featuredThreadsPrevious / featuredThreadsNext) since the buttons are real controls that scroll the embla carousel.
- CardActions: convert from <button> to <span aria-hidden="true">. The element has no onClick and is rendered inside a <Link>, so it was a purely decorative arrow indicator. Treating it as a button also created an invalid nested-interactive (button inside link), an extra focus stop, and the missing accessible name. Making it a non-interactive, aria-hidden span fixes all three.

## Summary

Brief description of changes.

## Changes

- Change 1
- Change 2

## Claudebin Session

<!-- Paste the claudebin.com link to the session used for this PR -->

🔗 [Session Link](https://claudebin.com/threads/...)

## Testing

How did you test this?

## Checklist

- [ ] `bun check` passes
- [ ] `bun type-check` passes
- [ ] Tested locally
- [ ] Claudebin session link attached
