### PR TITLE
fix(a11y): add accessible names to icon-only links

### DIFF
--- a/app/src/components/embed-page-footer.tsx
+++ b/app/src/components/embed-page-footer.tsx
@@ -32,7 +32,7 @@ export const EmbedPageFooter = ({
 
   return (
     <div className="sticky bottom-0 flex items-center justify-between border-gray-200 border-t bg-gray-100 p-4">
-      <Link href={`/threads/${id}`} target="_blank">
+      <Link href={`/threads/${id}`} target="_blank" aria-label={t("embed.openFullConversation")}>
         <SvgIconClaudebinXs
           size="auto"
           className="w-14 transition-colors duration-150 ease-in-out hover:text-orange-50"

--- a/app/src/components/ui/app-bar.tsx
+++ b/app/src/components/ui/app-bar.tsx
@@ -55,7 +55,11 @@ const AppBar = ({ className, ...props }: AppBarProps) => {
       <Container size="lg">
         <div className="flex items-center justify-between pt-3 pb-2">
           <div className="flex items-center gap-24">
-            <Link href="/" className="transition-colors ease-in-out hover:text-orange-50">
+            <Link
+              href="/"
+              aria-label={t("common.claudebinHome")}
+              className="transition-colors ease-in-out hover:text-orange-50"
+            >
               <SvgIconClaudebinXs size="auto" className="w-14" />
             </Link>
 

--- a/app/src/components/ui/footer.tsx
+++ b/app/src/components/ui/footer.tsx
@@ -57,7 +57,7 @@ const Footer = ({ className, ...props }: FooterProps) => {
 
         <div className="flex flex-col items-stretch justify-between gap-12 pt-3 pb-12 lg:flex-row">
           <div className="flex flex-col justify-between gap-4 lg:gap-6">
-            <Link href="/">
+            <Link href="/" aria-label={t("common.claudebinHome")}>
               <SvgIconClaudebin size="auto" className="max-w-xl" />
             </Link>
 

--- a/app/src/copy/en-EN.json
+++ b/app/src/copy/en-EN.json
@@ -35,7 +35,8 @@
     "image": "Image",
     "unlisted": "Unlisted",
     "sharingSettingsUpdated": "Sharing settings updated",
-    "sharingSettingsUpdateError": "Failed to update sharing settings"
+    "sharingSettingsUpdateError": "Failed to update sharing settings",
+    "claudebinHome": "Claudebin home"
   },
   "commands": {
     "oneClickInstall": "claude plugin marketplace add wunderlabs-dev/claudebin && claude plugin install claudebin@claudebin-marketplace",


### PR DESCRIPTION
Lighthouse flagged the Claudebin logo links in the app bar and footer for missing discernible names — they wrap a decorative SVG with no text or aria-label, so screen readers announce them as just "link".

- AppBar logo: aria-label via new common.claudebinHome string.
- Footer logo: same shared string.
- Embed footer logo: same root cause (icon-only link). Adds aria-label using the existing embed.openFullConversation key, which matches the link's destination (the full thread page).

## Summary

Brief description of changes.

## Changes

- Change 1
- Change 2

## Claudebin Session

<!-- Paste the claudebin.com link to the session used for this PR -->

🔗 [Session Link](https://claudebin.com/threads/...)

## Testing

How did you test this?

## Checklist

- [ ] `bun check` passes
- [ ] `bun type-check` passes
- [ ] Tested locally
- [ ] Claudebin session link attached
