### PR TITLE
fix(a11y): preserve heading order in footer

### DIFF
--- a/app/src/components/ui/footer.tsx
+++ b/app/src/components/ui/footer.tsx
@@ -74,7 +74,9 @@ const Footer = ({ className, ...props }: FooterProps) => {
           <div className="flex flex-col gap-6 sm:flex-row lg:gap-12">
             {sections.map((section) => (
               <nav key={section.title} className="flex flex-col gap-3">
-                <Typography variant="h4">{t(section.title)}</Typography>
+                <Typography variant="h4" as="h2">
+                  {t(section.title)}
+                </Typography>
 
                 {section.links.map((item) => (
                   <Link


### PR DESCRIPTION
Lighthouse flagged the footer section headings because the visual h4 variant renders as semantic <h4>, which skips heading levels on pages where the footer follows h1/h2 content.

Keep the existing h4 visual style but render the footer navigation section titles as <h2>. Footer sections are top-level landmark content, and <h2> avoids skipped heading levels across pages that may or may not include intermediate headings before the global footer.

## Summary

Brief description of changes.

## Changes

- Change 1
- Change 2

## Claudebin Session

<!-- Paste the claudebin.com link to the session used for this PR -->

🔗 [Session Link](https://claudebin.com/threads/...)

## Testing

How did you test this?

## Checklist

- [ ] `bun check` passes
- [ ] `bun type-check` passes
- [ ] Tested locally
- [ ] Claudebin session link attached
