### PR TITLE
fix(seo): exclude robots.txt and sitemap.xml from auth middleware

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -64,8 +64,9 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - robots.txt and sitemap.xml (crawler metadata, must be unauthenticated)
      * - public folder
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webm|mp4)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webm|mp4)$).*)",
   ],
 };


### PR DESCRIPTION
Lighthouse reports robots.txt as requiring authentication. The cause: the auth middleware's matcher does not exclude robots.txt or sitemap.xml, and PUBLIC_ROUTES does not list them either. Unauthenticated requests (every crawler, every Lighthouse run) hit the middleware, fail the isPublicRoute check, and get redirected to /auth/login — so bots see a login redirect instead of the robots policy.

Add robots.txt and sitemap.xml to the matcher's negative-lookahead exclusion, alongside favicon.ico. These are crawler metadata files; they must never go through Supabase auth, and the middleware has no reason to run for them at all. Same approach as the existing image/video exclusions.

## Summary

Brief description of changes.

## Changes

- Change 1
- Change 2

## Claudebin Session

<!-- Paste the claudebin.com link to the session used for this PR -->

🔗 [Session Link](https://claudebin.com/threads/...)

## Testing

How did you test this?

## Checklist

- [ ] `bun check` passes
- [ ] `bun type-check` passes
- [ ] Tested locally
- [ ] Claudebin session link attached
